### PR TITLE
Allow hyphens in karma words

### DIFF
--- a/pkg/karmabot/karmabot.go
+++ b/pkg/karmabot/karmabot.go
@@ -83,7 +83,7 @@ func NewKarmaBot(apiToken string, dbFile string) {
             splitText := strings.Fields(text)
             splitText = utils.FixEmptyKarma(splitText)
             for _, word := range splitText {
-                r := regexp.MustCompile("(.[A-Za-z0-9äëïöüÄËÏÖÜ<>@.]+?)([+-]+)$")
+                r := regexp.MustCompile("(.[A-Za-z0-9äëïöüÄËÏÖÜ<>@.-]+?)([+-]+)$")
                 matched := r.MatchString(word)
                 captureGroups := r.FindStringSubmatch(word)
                 if ev.User != info.User.ID && matched {


### PR DESCRIPTION
We use hyphens to separate words for teams and so on, would be nice for it to allow them on names.

```
# sbr-shift++ friday++
# friday has 1 karma points!
# -shift has 1 karma points!
```